### PR TITLE
経歴情報と受賞歴の更新

### DIFF
--- a/portfolio/src/masterdata/profile.ts
+++ b/portfolio/src/masterdata/profile.ts
@@ -405,17 +405,17 @@ export const experience = {
     {
       title: '株式会社infiniteloop',
       role: '長期インターン',
-      period: '2022年〜現在',
+      period: '2023年〜現在',
     },
     {
       title: '株式会社コロプラ',
       role: '2 Weeks インターン',
-      period: '2023年',
+      period: '2025年',
     },
     {
       title: 'プログラミングスクール',
       role: '講師',
-      period: '2023年〜現在',
+      period: '2024年〜現在',
     },
   ],
   awards: [
@@ -423,11 +423,6 @@ export const experience = {
       title: '未踏IT人材発掘・育成事業',
       role: '採択',
       period: '2025年',
-    },
-    {
-      title: '100Program 5期',
-      role: '2チーム同時ファイナリスト',
-      period: '2024年',
     },
     {
       title: '新雪プログラム',
@@ -447,6 +442,11 @@ export const experience = {
     {
       title: '北海道情報大学 ビジネスプレゼンテーションコンテスト',
       role: 'アイディア賞',
+      period: '2024年',
+    },
+    {
+      title: '100Program 5期',
+      role: '2チーム同時ファイナリスト',
       period: '2024年',
     },
   ],


### PR DESCRIPTION
## 概要
masterdataの経歴情報と受賞歴を最新の状態に更新しました。

## 変更内容

### 経歴の期間更新
- **株式会社infiniteloop 長期インターン**: 2022年 → 2023年〜現在
- **株式会社コロプラ インターン**: 2023年 → 2025年
- **プログラミングスクール講師**: 2023年 → 2024年〜現在

### 受賞歴の並び順変更
- 100Program 5期を時系列順に並び替え（最新の受賞歴の後に移動）

## テストプラン
- [x] ローカルでビルド確認
- [x] 経歴セクションの表示確認
- [ ] デプロイ後の本番環境確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 職務経歴の期間を最新情報に更新（infiniteloop: 2023年〜現在、コロプラ: 2025年、プログラミングスクール: 2024年〜現在）。
  * 受賞歴の表示順を調整し可読性を改善（「100Program 5期」を所定の位置へ移動）。
  * プロフィール表示を最新の実績に合わせて整備。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->